### PR TITLE
feature: add NukeCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/NukeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NukeCommand.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_INDEX;
+
+/**
+ * Deletes a person identified using it's displayed index from the address book.
+ */
+public class NukeCommand extends Command {
+
+    public static final String COMMAND_WORD = "nuke";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes all entries within a range of index. EndIndex must be more than StartIndex\n" + "Parameters: " + PREFIX_START_INDEX + "START_INDEX " + PREFIX_END_INDEX + "END_INDEX \n" + "Example: " + COMMAND_WORD + "si/1 ei/3";
+
+    public static final String MESSAGE_DELETE_ALL_SUCCESS = "Successfully deleted all entries";
+
+    private final Index startIndex;
+    private final Index endIndex;
+
+    public NukeCommand(Index startIndex, Index endIndex) {
+        this.startIndex = startIndex;
+        this.endIndex = endIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        int length = endIndex.getZeroBased() - startIndex.getZeroBased() + 1;
+        if (endIndex.getZeroBased() >= lastShownList.size() || endIndex.getZeroBased() < 0 || startIndex.getZeroBased() < 0) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        for (int i = 0; i < length; i++) {
+            Person personToDelete = lastShownList.get(startIndex.getZeroBased());
+            model.deletePerson(personToDelete);
+        }
+
+        return new CommandResult(MESSAGE_DELETE_ALL_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteCommand)) {
+            return false;
+        }
+
+        NukeCommand otherNukeCommand = (NukeCommand) other;
+        return startIndex.equals(otherNukeCommand.startIndex) && endIndex.equals(otherNukeCommand.endIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("startIndex", startIndex).add("endIndex", endIndex).toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,15 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +68,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case NukeCommand.COMMAND_WORD:
+            return new NukeCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_START_INDEX = new Prefix("si/");
+    public static final Prefix PREFIX_END_INDEX = new Prefix("ei/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/NukeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NukeCommandParser.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.NukeCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Name;
+
+import java.util.stream.Stream;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_INDEX;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object
+ */
+public class NukeCommandParser implements Parser<NukeCommand> {
+
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteCommand
+     * and returns a DeleteCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public NukeCommand parse(String args) throws ParseException {
+        try {
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_START_INDEX, PREFIX_END_INDEX);
+            if (!arePrefixesPresent(argMultimap, PREFIX_START_INDEX, PREFIX_END_INDEX) || !argMultimap.getPreamble().isEmpty()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NukeCommand.MESSAGE_USAGE));
+            }
+
+            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_START_INDEX, PREFIX_END_INDEX);
+            Index startIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_START_INDEX).get());
+            Index endIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_END_INDEX).get());
+            if (endIndex.getZeroBased() <= startIndex.getZeroBased()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NukeCommand.MESSAGE_USAGE));
+            }
+            return new NukeCommand(startIndex, endIndex);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NukeCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}


### PR DESCRIPTION
Add NukeCommand.
NukeCommand takes two indexes and deletes all entries in the range of the two indexes. This is useful when removing a large number of entries at one time.