### PR TITLE
Fix test cases and test cases fails related to create and delete

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,11 +1,20 @@
 package seedu.address.logic;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
+import seedu.address.model.person.Allergies;
+import seedu.address.model.person.BloodType;
+import seedu.address.model.person.Condition;
+import seedu.address.model.person.Country;
+import seedu.address.model.person.DateOfAdmission;
+import seedu.address.model.person.Diagnosis;
+import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Symptom;
 
 /**
  * Container for user visible messages.
@@ -14,7 +23,6 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_NRIC_NOT_FOUND = "The NRIC provided is not found in the system";
     public static final String MESSAGE_PERSON_NOT_FOUND = "The person provided was not found";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
@@ -37,6 +45,14 @@ public class Messages {
      */
     public static String format(Person person) {
         final StringBuilder builder = new StringBuilder();
+        Optional<Email> email = Optional.ofNullable(person.getEmail());
+        Optional<Country> country = Optional.ofNullable(person.getCountry());
+        Optional<Allergies> allergies = Optional.ofNullable(person.getAllergies());
+        Optional<BloodType> bloodType = Optional.ofNullable(person.getBloodType());
+        Optional<Condition> condition = Optional.ofNullable(person.getCondition());
+        Optional<DateOfAdmission> dateOfAdmission = Optional.ofNullable(person.getDateOfAdmission());
+        Optional<Diagnosis> diagnosis = Optional.ofNullable(person.getDiagnosis());
+        Optional<Symptom> symptom = Optional.ofNullable(person.getSymptom());
         builder.append(person.getName())
                 .append("; NRIC: ")
                 .append(person.getNric())
@@ -51,21 +67,21 @@ public class Messages {
                 .append("; Status: ")
                 .append(person.getStatus())
                 .append("; Email: ")
-                .append(person.getEmail().orElse("-"))
+                .append(Optional.ofNullable(person.getEmail()).map(Object::toString).orElse("-"))
                 .append("; Country: ")
-                .append(person.getCountry().orElse("-"))
+                .append(Optional.ofNullable(person.getCountry()).map(Object::toString).orElse("-"))
                 .append("; Allergies: ")
-                .append(person.getAllergies().orElse("-"))
+                .append(Optional.ofNullable(person.getAllergies()).map(Object::toString).orElse("-"))
                 .append("; Blood Type: ")
-                .append(person.getBloodType().orElse("-"))
+                .append(Optional.ofNullable(person.getBloodType()).map(Object::toString).orElse("-"))
                 .append("; Condition: ")
-                .append(person.getCondition().orElse("-"))
+                .append(Optional.ofNullable(person.getCondition()).map(Object::toString).orElse("-"))
                 .append("; DOA: ")
-                .append(person.getDateOfAdmission().orElse("-"))
+                .append(Optional.ofNullable(person.getDateOfAdmission()).map(Object::toString).orElse("-"))
                 .append("; Diagnosis: ")
-                .append(person.getDiagnosis().orElse("-"))
+                .append(Optional.ofNullable(person.getDiagnosis()).map(Object::toString).orElse("-"))
                 .append("; Symptom: ")
-                .append(person.getSymptom().orElse("-"))
+                .append(Optional.ofNullable(person.getSymptom()).map(Object::toString).orElse("-"))
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -37,7 +37,7 @@ public class DeleteCommand extends Command {
 
         ObservableList<Person> persons = model.getFilteredPersonList();
         if (!model.hasPerson(Person.createPersonWithNric(targetNric))) {
-            throw new CommandException(Messages.MESSAGE_NRIC_NOT_FOUND);
+            throw new CommandException(Messages.MESSAGE_PERSON_NOT_FOUND);
         }
         //Difference between filteredPersons.contains and model.hasPerson: first checks if the instance is in the list,
         //second checks if the NRIC is in the list

--- a/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
@@ -55,7 +55,7 @@ public class CreateCommandParser implements Parser<CreateCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_NAME, PREFIX_PHONE, PREFIX_ADDRESS,
-                PREFIX_DATEOFBIRTH, PREFIX_SEX);
+                PREFIX_DATEOFBIRTH, PREFIX_SEX, PREFIX_STATUS);
         Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
@@ -63,7 +63,7 @@ public class CreateCommandParser implements Parser<CreateCommand> {
         DateOfBirth dob = ParserUtil.parseDateOfBirth(argMultimap.getValue(PREFIX_DATEOFBIRTH).get());
         Sex sex = ParserUtil.parseSex(argMultimap.getValue(PREFIX_SEX).get());
         Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
-        //TODO (later): assersion to make sure optinal values don't generate errors
+        //TODO (later): assersion to make sure optional values don't generate errors
         Person person = new Person(nric, name, phone, address, dob, sex, status);
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
             Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -239,6 +239,19 @@ public class Person {
     }
 
     /**
+     * Returns true if the person has all mandatory fields.
+     */
+    public static boolean isValidPerson(Person person) {
+        return person.nric != null
+                && person.name != null
+                && person.phone != null
+                && person.address != null
+                && person.dateOfBirth != null
+                && person.sex != null
+                && person.status != null;
+    }
+
+    /**
      * Returns true if both persons have the same identity and all data fields.
      * This defines a stronger notion of equality between two persons.
      */
@@ -253,6 +266,9 @@ public class Person {
             return false;
         }
         Person otherPerson = (Person) other;
+        if (!(isValidPerson(this) && isValidPerson(otherPerson))) {
+            return false;
+        }
         return nric.equals(otherPerson.nric)
                 && name.equals(otherPerson.name)
                 && phone.equals(otherPerson.phone)
@@ -261,14 +277,14 @@ public class Person {
                 && sex.equals(otherPerson.sex)
                 && status.equals(otherPerson.status)
                 && tags.equals(otherPerson.tags)
-                && email.equals(otherPerson.email)
-                && country.equals(otherPerson.country)
-                && allergies.equals(otherPerson.allergies)
-                && bloodType.equals(otherPerson.bloodType)
-                && condition.equals(otherPerson.condition)
-                && dateOfAdmission.equals(otherPerson.dateOfAdmission)
-                && diagnosis.equals(otherPerson.diagnosis)
-                && symptom.equals(otherPerson.symptom);
+                && Objects.equals(email, otherPerson.email)
+                && Objects.equals(country, otherPerson.country)
+                && Objects.equals(allergies, otherPerson.allergies)
+                && Objects.equals(bloodType, otherPerson.bloodType)
+                && Objects.equals(condition, otherPerson.condition)
+                && Objects.equals(dateOfAdmission, otherPerson.dateOfAdmission)
+                && Objects.equals(diagnosis, otherPerson.diagnosis)
+                && Objects.equals(symptom, otherPerson.symptom);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNTRY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATEOFBIRTH;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
@@ -65,6 +66,8 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
+    public static final String NRIC_DESC_AMY = " " + PREFIX_NRIC + VALID_NRIC_AMY;
+    public static final String NRIC_DESC_BOB = " " + PREFIX_NRIC + VALID_NRIC_BOB;
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;

--- a/src/test/java/seedu/address/logic/parser/CreateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CreateCommandParserTest.java
@@ -3,30 +3,34 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.DATEOFBIRTH_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DATEOFBIRTH_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.SEX_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.SEX_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.STATUS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.STATUS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATEOFBIRTH;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPersons.AMY;
@@ -37,11 +41,9 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.CreateCommand;
 import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
 public class CreateCommandParserTest {
@@ -52,23 +54,29 @@ public class CreateCommandParserTest {
         Person expectedPerson = new PersonBuilder(BOB).build();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new CreateCommand(expectedPerson));
-
-
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NRIC_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB
+                + ADDRESS_DESC_BOB + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
+                new CreateCommand(expectedPerson));
+        //TODO: after implementing optional fields for person builder
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder(BOB)
                 .build();
         assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                NRIC_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB + ADDRESS_DESC_BOB
+                        + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
                 new CreateCommand(expectedPersonMultipleTags));
     }
 
+
     @Test
     public void parse_repeatedNonTagValue_failure() {
-        String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND;
+        //TODO: add in optional fields (after person builder)
+        String validExpectedPersonString = NRIC_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB
+                + ADDRESS_DESC_BOB + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB;
 
+        //multiple nrics
+        assertParseFailure(parser, NRIC_DESC_BOB + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NRIC));
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
@@ -77,9 +85,12 @@ public class CreateCommandParserTest {
         assertParseFailure(parser, PHONE_DESC_AMY + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
+        //TODO: after implementing optional fields for person builder
+        /*
         // multiple emails
         assertParseFailure(parser, EMAIL_DESC_AMY + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
+        */
 
         // multiple addresses
         assertParseFailure(parser, ADDRESS_DESC_AMY + validExpectedPersonString,
@@ -87,19 +98,22 @@ public class CreateCommandParserTest {
 
         // multiple fields repeated
         assertParseFailure(parser,
-                validExpectedPersonString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY
+                validExpectedPersonString + PHONE_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY
                         + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_NRIC, PREFIX_DATEOFBIRTH, PREFIX_SEX,
+                        PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_STATUS));
 
         // invalid value followed by valid value
 
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
-
+        /*
         // invalid email
         assertParseFailure(parser, INVALID_EMAIL_DESC + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
+
+         */
 
         // invalid phone
         assertParseFailure(parser, INVALID_PHONE_DESC + validExpectedPersonString,
@@ -115,10 +129,11 @@ public class CreateCommandParserTest {
         assertParseFailure(parser, validExpectedPersonString + INVALID_NAME_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
 
+        /*
         // invalid email
         assertParseFailure(parser, validExpectedPersonString + INVALID_EMAIL_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
-
+         */
         // invalid phone
         assertParseFailure(parser, validExpectedPersonString + INVALID_PHONE_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
@@ -132,7 +147,8 @@ public class CreateCommandParserTest {
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         Person expectedPerson = new PersonBuilder(AMY).build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
+        assertParseSuccess(parser, NRIC_DESC_AMY + NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY
+                + DATEOFBIRTH_DESC_AMY + SEX_DESC_AMY + STATUS_DESC_AMY,
                 new CreateCommand(expectedPerson));
     }
 
@@ -140,56 +156,61 @@ public class CreateCommandParserTest {
     public void parse_compulsoryFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateCommand.MESSAGE_USAGE);
 
+        // missing nric prefix
+        assertParseFailure(parser, VALID_NRIC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB + ADDRESS_DESC_BOB
+                        + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
+                expectedMessage);
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
+        assertParseFailure(parser, NRIC_DESC_BOB + VALID_NAME_BOB + PHONE_DESC_BOB + ADDRESS_DESC_BOB
+                        + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
                 expectedMessage);
 
         // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
-
-        // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
+        assertParseFailure(parser, NRIC_DESC_BOB + NAME_DESC_BOB + VALID_PHONE_BOB + ADDRESS_DESC_BOB
+                        + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
                 expectedMessage);
 
         // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
+        assertParseFailure(parser, NRIC_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB + VALID_ADDRESS_BOB
+                        + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
                 expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,
+        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_ADDRESS_BOB,
                 expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, NRIC_DESC_BOB + INVALID_NAME_DESC + PHONE_DESC_BOB + ADDRESS_DESC_BOB
+                + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
-        assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
-
+        assertParseFailure(parser, NRIC_DESC_BOB + NAME_DESC_BOB + INVALID_PHONE_DESC + ADDRESS_DESC_BOB
+                + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB, Phone.MESSAGE_CONSTRAINTS);
+        //TODO: optional fields
+        /*
         // invalid email
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
-
+        assertParseFailure(parser, NRIC_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB + ADDRESS_DESC_BOB
+                + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB, Email.MESSAGE_CONSTRAINTS);
+         */
         // invalid address
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
-
+        assertParseFailure(parser, NRIC_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_ADDRESS_DESC
+                + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB, Address.MESSAGE_CONSTRAINTS);
+        /*
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
-
+        */
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,
+        assertParseFailure(parser, NRIC_DESC_BOB + INVALID_NAME_DESC + PHONE_DESC_BOB + INVALID_ADDRESS_DESC
+                        + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
                 Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NRIC_DESC_BOB + NAME_DESC_BOB
+                        + PHONE_DESC_BOB + ADDRESS_DESC_BOB + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -94,9 +94,10 @@ public class PersonBuilder {
         phone = personToCopy.getPhone();
         dateOfBirth = personToCopy.getDateOfBirth();
         sex = personToCopy.getSex();
+        address = personToCopy.getAddress();
+        status = personToCopy.getStatus();
 
         /*
-        address = personToCopy.getAddress();
         allergies = personToCopy.getAllergies();
         bloodType = personToCopy.getBloodType();
         country = personToCopy.getCountry();
@@ -105,7 +106,6 @@ public class PersonBuilder {
         condition = personToCopy.getCondition();
         dateOfAdmission = personToCopy.getDateOfAdmission();
         diagnosis = personToCopy.getDiagnosis();
-        status = personToCopy.getStatus();
         symptom = personToCopy.getSymptom();
          */
     }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -64,6 +64,7 @@ public class TypicalPersons {
     public static final Person BOB = new PersonBuilder().withNric(VALID_NRIC_BOB).withName(VALID_NAME_BOB)
             .withPhone(VALID_PHONE_BOB).withAddress(VALID_ADDRESS_BOB).withDateOfBirth(VALID_DATEOFBIRTH_BOB)
             .withSex(VALID_SEX_BOB).withStatus(VALID_STATUS_BOB).build();
+    //TODO: person builder should be able to build a person with all fields (status)
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 


### PR DESCRIPTION
Fix #81 #16 

Message: Standardize Person Not Found message
Consider optional fields

DeleteCommand: use MESSAGE_PERSON_NOT_FOUND instead

CreateCommandParser: Check duplicates for PREFIX_STATUS

Person: Add isValidPerson() method; Adjust equals() to account for null optional fields

CommandTestUtil: Add all necessary DESC

CreateCommandParserTest: Make compatible to current structure

PersonBuilder: Consider all mandatory fields only