### PR TITLE
Update command box prompt color

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -326,6 +326,7 @@
     -fx-font-family: "Roboto";
     -fx-font-size: 16pt;
     -fx-text-fill: white;
+    -fx-prompt-text-fill: white;
 }
 
 #filterField, #personListPanel, #personWebpage {


### PR DESCRIPTION
CommandBox Prompt Text Color was gray and unable to be seen properly. Update it to be white so it's more visible.