### PR TITLE
Fix AddVisitCommand and Storage bug. Init Visit TestUtils and Test Cases

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -48,6 +48,7 @@ public class LogicManager implements Logic {
 
         CommandResult commandResult;
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredVisitList(Model.PREDICATE_SHOW_ALL_VISITS);
         Command command = immuniMateParser.parseCommand(commandText);
         commandResult = command.execute(model);
 

--- a/src/main/java/seedu/address/logic/commands/AddVisitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddVisitCommand.java
@@ -11,6 +11,8 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
 import seedu.address.model.visit.Visit;
 
 /**
@@ -34,7 +36,8 @@ public class AddVisitCommand extends Command {
             + PREFIX_STATUS + "PENDING";
 
     public static final String MESSAGE_SUCCESS = "New Visit added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This visit already exists in the system";
+    public static final String MESSAGE_DUPLICATE_VISIT = "This visit already exists in the system";
+    public static final String MESSAGE_INVALID_VISIT = "The NRIC supplied does not link to any existing Patient";
 
     private final Visit toAdd;
 
@@ -50,9 +53,14 @@ public class AddVisitCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
+        Nric patientNric = toAdd.getNric();
+        Person patient = Person.createPersonWithNric(patientNric);
+        // Guard clauses to ensure NRIC is valid and Visit is not duplicate
+        if (!model.hasPerson(patient)) {
+            throw new CommandException(MESSAGE_INVALID_VISIT);
+        }
         if (model.hasVisit(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            throw new CommandException(MESSAGE_DUPLICATE_VISIT);
         }
         //TODO: Update patient symptom and diagnosis to reflect latest visit!
         model.addVisit(toAdd);

--- a/src/main/java/seedu/address/logic/parser/AddVisitCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddVisitCommandParser.java
@@ -42,11 +42,13 @@ public class AddVisitCommandParser implements Parser<AddVisitCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_DATEOFVISIT,
             PREFIX_SYMPTOM, PREFIX_DIAGNOSIS, PREFIX_STATUS);
         Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+
+
         DateOfVisit dov = ParserUtil.parseDateOfVisit(argMultimap.getValue(PREFIX_DATEOFVISIT).get());
         Symptom symptom = ParserUtil.parseSymptom(argMultimap.getValue(PREFIX_SYMPTOM).get());
         Diagnosis diagnosis = ParserUtil.parseDiagnosis(argMultimap.getValue(PREFIX_DIAGNOSIS).get());
         Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
-        //TODO (later): assersion to make sure optional values don't generate errors
+
         Visit visit = new Visit(nric, dov, symptom, diagnosis, status);
 
         return new AddVisitCommand(visit);

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -44,9 +44,9 @@ public class SampleDataUtil {
 
     public static Visit[] getSampleVisits() {
         return new Visit[] {
-            new Visit(new Nric("T0245123C"), new DateOfVisit("2023-01-02"),
+            new Visit(new Nric("T0234567C"), new DateOfVisit("2023-01-02"),
                     new Symptom("Dying"), new Diagnosis("Cancer"), new Status("UNWELL")),
-            new Visit(new Nric("T0245123C"), new DateOfVisit("2023-02-25"),
+            new Visit(new Nric("T0234567C"), new DateOfVisit("2023-02-25"),
                     new Symptom("Throat Pain"), new Diagnosis("Cancer"), new Status("HEALTHY")),
             new Visit(new Nric("S9234568N"), new DateOfVisit("2023-01-02"),
                     new Symptom("Headache"), new Diagnosis("COVID"), new Status("UNWELL")),

--- a/src/main/java/seedu/address/model/visit/Visit.java
+++ b/src/main/java/seedu/address/model/visit/Visit.java
@@ -52,18 +52,6 @@ public class Visit {
     }
 
     /**
-     * Returns true if both persons have the same nric.
-     * This defines a weaker notion of equality between two persons.
-     */
-    public boolean isSamePerson(Visit otherPerson) {
-        if (otherPerson == this) {
-            return true;
-        }
-
-        return otherPerson != null && otherPerson.getNric().equals(getNric());
-    }
-
-    /**
      * Returns true if the person has all mandatory fields.
      */
     public static boolean isValidVisit(Visit visit) {

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -62,7 +62,7 @@ public class CommandBox extends UiPart<Region> {
         }
 
         // Guard Clause for initial key input. Shows first command without skipping it.
-        if (historyIndex == 0 && isFirstPress) {
+        if (historyIndex == 0 && isFirstPress && direction == 1) {
             commandTextField.setText(commandHistory.get(historyIndex));
             System.out.println("HistoryIndex: " + historyIndex + " NextCommand: " + commandHistory.get(historyIndex));
             isFirstPress = false;

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -64,7 +64,6 @@ public class CommandBox extends UiPart<Region> {
         // Guard Clause for initial key input. Shows first command without skipping it.
         if (historyIndex == 0 && isFirstPress && direction == 1) {
             commandTextField.setText(commandHistory.get(historyIndex));
-            System.out.println("HistoryIndex: " + historyIndex + " NextCommand: " + commandHistory.get(historyIndex));
             isFirstPress = false;
             return;
         }
@@ -80,7 +79,6 @@ public class CommandBox extends UiPart<Region> {
         } else if (historyIndex >= commandHistory.size()) {
             historyIndex = commandHistory.size();
         }
-        System.out.println("HistoryIndex: " + historyIndex + " NextCommand: " + commandHistory.get(historyIndex));
         // Set the commandTextField's text to the command at the new history index
         commandTextField.setText(commandHistory.get(historyIndex));
     }

--- a/src/test/java/seedu/address/logic/commands/AddVisitCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddVisitCommandIntegrationTest.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code AddCommand}.
+ */
+public class AddVisitCommandIntegrationTest {
+
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_newVisit_success() {
+        Person validPerson = new PersonBuilder().build();
+
+        Model expectedModel = new ModelManager(model.getImmuniMate(), new UserPrefs());
+        expectedModel.addPerson(validPerson);
+
+        assertCommandSuccess(new CreateCommand(validPerson), model,
+                String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+                expectedModel);
+    }
+
+    @Test
+    public void execute_duplicatePerson_throwsCommandException() {
+        Person personInList = model.getImmuniMate().getPersonList().get(0);
+        assertCommandFailure(new CreateCommand(personInList), model,
+                CreateCommand.MESSAGE_DUPLICATE_PERSON);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/AddVisitCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddVisitCommandIntegrationTest.java
@@ -1,17 +1,18 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
-
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code AddCommand}.

--- a/src/test/java/seedu/address/logic/commands/AddVisitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddVisitCommandTest.java
@@ -1,0 +1,234 @@
+package seedu.address.logic.commands;
+
+import javafx.collections.ObservableList;
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.ImmuniMate;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyImmuniMate;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.visit.Visit;
+import seedu.address.testutil.PersonBuilder;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+
+// TODO Adjust Test Cases
+public class AddVisitCommandTest {
+
+    @Test
+    public void constructor_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new CreateCommand(null));
+    }
+
+    @Test
+    public void execute_personAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
+        Person validPerson = new PersonBuilder().build();
+
+        CommandResult commandResult = new CreateCommand(validPerson).execute(modelStub);
+
+        assertEquals(String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+                commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
+    }
+
+    @Test
+    public void execute_duplicatePerson_throwsCommandException() {
+        Person validPerson = new PersonBuilder().build();
+        CreateCommand createCommand = new CreateCommand(validPerson);
+        ModelStub modelStub = new ModelStubWithPerson(validPerson);
+
+        assertThrows(CommandException.class,
+                CreateCommand.MESSAGE_DUPLICATE_PERSON, () -> createCommand.execute(modelStub));
+    }
+
+    @Test
+    public void equals() {
+        Person alice = new PersonBuilder().withName("Alice").build();
+        Person bob = new PersonBuilder().withName("Bob").build();
+        CreateCommand addAliceCommand = new CreateCommand(alice);
+        CreateCommand addBobCommand = new CreateCommand(bob);
+
+        // same object -> returns true
+        assertTrue(addAliceCommand.equals(addAliceCommand));
+
+        // same values -> returns true
+        CreateCommand addAliceCommandCopy = new CreateCommand(alice);
+        assertTrue(addAliceCommand.equals(addAliceCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addAliceCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addAliceCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(addAliceCommand.equals(addBobCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        CreateCommand createCommand = new CreateCommand(ALICE);
+        String expected = CreateCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
+        assertEquals(expected, createCommand.toString());
+    }
+
+    /**
+     * A default model stub that have all the methods failing.
+     */
+    private class ModelStub implements Model {
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getImmunimateFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setImmunimateFilePath(Path immuniMateFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addVisit(Visit visit) {
+
+        }
+
+        @Override
+        public void setImmuniMate(ReadOnlyImmuniMate immuniMate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyImmuniMate getImmuniMate() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasVisit(Visit visit) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteVisit(Visit target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setVisit(Visit target, Visit editedVisit) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Visit> getFilteredVisitList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredVisitList(Predicate<Visit> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+    }
+
+    /**
+     * A Model stub that contains a single person.
+     */
+    private class ModelStubWithPerson extends ModelStub {
+        private final Person person;
+
+        ModelStubWithPerson(Person person) {
+            requireNonNull(person);
+            this.person = person;
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            requireNonNull(person);
+            return this.person.isSamePerson(person);
+        }
+    }
+
+    /**
+     * A Model stub that always accept the person being added.
+     */
+    private class ModelStubAcceptingPersonAdded extends ModelStub {
+        final ArrayList<Person> personsAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasPerson(Person person) {
+            requireNonNull(person);
+            return personsAdded.stream().anyMatch(person::isSamePerson);
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            requireNonNull(person);
+            personsAdded.add(person);
+        }
+
+        @Override
+        public ReadOnlyImmuniMate getImmuniMate() {
+            return new ImmuniMate();
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/AddVisitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddVisitCommandTest.java
@@ -1,7 +1,20 @@
 package seedu.address.logic.commands;
 
-import javafx.collections.ObservableList;
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -13,15 +26,6 @@ import seedu.address.model.person.Person;
 import seedu.address.model.visit.Visit;
 import seedu.address.testutil.PersonBuilder;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.function.Predicate;
-
-import static java.util.Objects.requireNonNull;
-import static org.junit.jupiter.api.Assertions.*;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
 
 // TODO Adjust Test Cases
 public class AddVisitCommandTest {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -49,6 +49,8 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_DATEOFBIRTH_AMY = "2001-01-01";
     public static final String VALID_DATEOFBIRTH_BOB = "2002-02-02";
+    public static final String VALID_DATEOFVISIT_AMY = "2023-12-01";
+    public static final String VALID_DATEOFVISIT_BOB = "2019-08-05";
     public static final String VALID_SEX_AMY = "F";
     public static final String VALID_SEX_BOB = "M";
     public static final String VALID_STATUS_AMY = "HEALTHY";

--- a/src/test/java/seedu/address/logic/parser/AddVisitCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddVisitCommandParserTest.java
@@ -1,6 +1,44 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.ALL_FIELDS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.DATEOFBIRTH_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DATEOFBIRTH_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_AMI;
+import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.SEX_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.SEX_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.STATUS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.STATUS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATEOFBIRTH;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalPersons.AMI;
+import static seedu.address.testutil.TypicalPersons.BOB;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.CreateCommand;
 import seedu.address.model.person.Address;
@@ -8,14 +46,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.testutil.PersonBuilder;
-
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.*;
-import static seedu.address.logic.parser.CliSyntax.*;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalPersons.AMI;
-import static seedu.address.testutil.TypicalPersons.BOB;
 
 // TODO Adjust Test Cases
 public class AddVisitCommandParserTest {

--- a/src/test/java/seedu/address/logic/parser/AddVisitCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddVisitCommandParserTest.java
@@ -1,0 +1,179 @@
+package seedu.address.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.CreateCommand;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.testutil.PersonBuilder;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalPersons.AMI;
+import static seedu.address.testutil.TypicalPersons.BOB;
+
+// TODO Adjust Test Cases
+public class AddVisitCommandParserTest {
+    private CreateCommandParser parser = new CreateCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Person expectedPerson = new PersonBuilder(BOB).build();
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + ALL_FIELDS_DESC_BOB, new CreateCommand(expectedPerson));
+        //TODO: after implementing optional fields for person builder
+    }
+
+
+    @Test
+    public void parse_repeatedNonTagValue_failure() {
+        //TODO: add in optional fields (after person builder)
+        String validExpectedPersonString = NRIC_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB
+                + ADDRESS_DESC_BOB + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB;
+
+        //multiple nrics
+        assertParseFailure(parser, NRIC_DESC_BOB + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NRIC));
+        // multiple names
+        assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+
+        // multiple phones
+        assertParseFailure(parser, PHONE_DESC_AMY + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+
+        //TODO: after implementing optional fields for person builder
+        /*
+        // multiple emails
+        assertParseFailure(parser, EMAIL_DESC_AMY + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
+        */
+
+        // multiple addresses
+        assertParseFailure(parser, ADDRESS_DESC_AMY + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
+
+        // multiple fields repeated
+        assertParseFailure(parser,
+                validExpectedPersonString + PHONE_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY
+                        + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_NRIC, PREFIX_DATEOFBIRTH, PREFIX_SEX,
+                        PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_STATUS));
+
+        // invalid value followed by valid value
+
+        // invalid name
+        assertParseFailure(parser, INVALID_NAME_DESC + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+        /*
+        // invalid email
+        assertParseFailure(parser, INVALID_EMAIL_DESC + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
+
+         */
+
+        // invalid phone
+        assertParseFailure(parser, INVALID_PHONE_DESC + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+
+        // invalid address
+        assertParseFailure(parser, INVALID_ADDRESS_DESC + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
+
+        // valid value followed by invalid value
+
+        // invalid name
+        assertParseFailure(parser, validExpectedPersonString + INVALID_NAME_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+
+        /*
+        // invalid email
+        assertParseFailure(parser, validExpectedPersonString + INVALID_EMAIL_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
+         */
+        // invalid phone
+        assertParseFailure(parser, validExpectedPersonString + INVALID_PHONE_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+
+        // invalid address
+        assertParseFailure(parser, validExpectedPersonString + INVALID_ADDRESS_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
+    }
+
+    @Test
+    public void parse_optionalFieldsMissing_success() {
+        // zero tags
+        Person expectedPerson = new PersonBuilder(AMI).build();
+        assertParseSuccess(parser, NRIC_DESC_AMI + NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY
+                + DATEOFBIRTH_DESC_AMY + SEX_DESC_AMY + STATUS_DESC_AMY,
+                new CreateCommand(expectedPerson));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateCommand.MESSAGE_USAGE);
+
+        // missing nric prefix
+        assertParseFailure(parser, VALID_NRIC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB + ADDRESS_DESC_BOB
+                        + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
+                expectedMessage);
+        // missing name prefix
+        assertParseFailure(parser, NRIC_DESC_BOB + VALID_NAME_BOB + PHONE_DESC_BOB + ADDRESS_DESC_BOB
+                        + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
+                expectedMessage);
+
+        // missing phone prefix
+        assertParseFailure(parser, NRIC_DESC_BOB + NAME_DESC_BOB + VALID_PHONE_BOB + ADDRESS_DESC_BOB
+                        + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
+                expectedMessage);
+
+        // missing address prefix
+        assertParseFailure(parser, NRIC_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB + VALID_ADDRESS_BOB
+                        + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
+                expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_ADDRESS_BOB,
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, NRIC_DESC_BOB + INVALID_NAME_DESC + PHONE_DESC_BOB + ADDRESS_DESC_BOB
+                + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB, Name.MESSAGE_CONSTRAINTS);
+
+        // invalid phone
+        assertParseFailure(parser, NRIC_DESC_BOB + NAME_DESC_BOB + INVALID_PHONE_DESC + ADDRESS_DESC_BOB
+                + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB, Phone.MESSAGE_CONSTRAINTS);
+        //TODO: optional fields
+        /*
+        // invalid email
+        assertParseFailure(parser, NRIC_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB + ADDRESS_DESC_BOB
+                + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB, Email.MESSAGE_CONSTRAINTS);
+         */
+        // invalid address
+        assertParseFailure(parser, NRIC_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_ADDRESS_DESC
+                + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB, Address.MESSAGE_CONSTRAINTS);
+        /*
+        // invalid tag
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+        */
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, NRIC_DESC_BOB + INVALID_NAME_DESC + PHONE_DESC_BOB + INVALID_ADDRESS_DESC
+                        + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
+                Name.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NRIC_DESC_BOB + NAME_DESC_BOB
+                        + PHONE_DESC_BOB + ADDRESS_DESC_BOB + DATEOFBIRTH_DESC_BOB + SEX_DESC_BOB + STATUS_DESC_BOB,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/person/DateOfBirthTest.java
+++ b/src/test/java/seedu/address/model/person/DateOfBirthTest.java
@@ -22,16 +22,16 @@ public class DateOfBirthTest {
     @Test
     public void isValidDateOfBirth() {
         // invalid addresses
-        assertFalse(DateOfAdmission.isValidDateOfAdmission("")); // empty string
-        assertFalse(DateOfAdmission.isValidDateOfAdmission(" ")); // spaces only
-        assertFalse(DateOfAdmission.isValidDateOfAdmission("20231213")); // numbers only
-        assertFalse(DateOfAdmission.isValidDateOfAdmission("2023-1213")); // one slash
-        assertFalse(DateOfAdmission.isValidDateOfAdmission("202312-13")); // one slash
-        assertFalse(DateOfAdmission.isValidDateOfAdmission("2023-1-3")); // shortened date and month
-        assertFalse(DateOfAdmission.isValidDateOfAdmission("13-12-2023")); // reverse format
+        assertFalse(DateOfBirth.isValidDateOfBirth("")); // empty string
+        assertFalse(DateOfBirth.isValidDateOfBirth(" ")); // spaces only
+        assertFalse(DateOfBirth.isValidDateOfBirth("20231213")); // numbers only
+        assertFalse(DateOfBirth.isValidDateOfBirth("2023-1213")); // one slash
+        assertFalse(DateOfBirth.isValidDateOfBirth("202312-13")); // one slash
+        assertFalse(DateOfBirth.isValidDateOfBirth("2023-1-3")); // shortened date and month
+        assertFalse(DateOfBirth.isValidDateOfBirth("13-12-2023")); // reverse format
 
         // valid addresses
-        assertTrue(DateOfAdmission.isValidDateOfAdmission("2023-12-13"));
+        assertTrue(DateOfBirth.isValidDateOfBirth("2023-12-13"));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/visit/DateOfVisitTest.java
+++ b/src/test/java/seedu/address/model/visit/DateOfVisitTest.java
@@ -1,0 +1,43 @@
+package seedu.address.model.visit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class DateOfVisitTest {
+    @Test
+    public void isValidDateOfVisit() {
+        // invalid addresses
+        assertFalse(DateOfVisit.isValidDateOfVisit("")); // empty string
+        assertFalse(DateOfVisit.isValidDateOfVisit(" ")); // spaces only
+        assertFalse(DateOfVisit.isValidDateOfVisit("20231213")); // numbers only
+        assertFalse(DateOfVisit.isValidDateOfVisit("2023-1213")); // one slash
+        assertFalse(DateOfVisit.isValidDateOfVisit("202312-13")); // one slash
+        assertFalse(DateOfVisit.isValidDateOfVisit("2023-1-3")); // shortened date and month
+        assertFalse(DateOfVisit.isValidDateOfVisit("13-12-2023")); // reverse format
+
+        // valid addresses
+        assertTrue(DateOfVisit.isValidDateOfVisit("2023-12-13"));
+    }
+
+    @Test
+    public void equals() {
+        DateOfVisit date = new DateOfVisit("2020-12-05");
+
+        // same values -> returns true
+        assertTrue(date.equals(new DateOfVisit("2020-12-05")));
+
+        // same object -> returns true
+        assertTrue(date.equals(date));
+
+        // null -> returns false
+        assertFalse(date.equals(null));
+
+        // different types -> returns false
+        assertFalse(date.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(date.equals(new DateOfVisit("2023-12-13")));
+    }
+}

--- a/src/test/java/seedu/address/model/visit/VisitTest.java
+++ b/src/test/java/seedu/address/model/visit/VisitTest.java
@@ -1,0 +1,92 @@
+package seedu.address.model.visit;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SEX_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_BOB;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+
+public class VisitTest {
+
+    @Test
+    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
+        Person person = new PersonBuilder().build();
+        assertThrows(UnsupportedOperationException.class, () -> person.getTags().remove(0));
+    }
+
+    @Test
+    public void isSameVisit() {
+        // same object -> returns true
+        assertTrue(ALICE.isSamePerson(ALICE));
+
+        // null -> returns false
+        assertFalse(ALICE.isSamePerson(null));
+
+        // same nric, all other attributes different -> returns true
+        Person editedAlice =
+            new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withAddress(VALID_ADDRESS_BOB).withName(VALID_NAME_BOB)
+                .withSex(VALID_SEX_BOB).withStatus(VALID_STATUS_BOB).build();
+        assertTrue(ALICE.isSamePerson(editedAlice));
+
+        // different NRIC, all other attributes same -> returns false
+        editedAlice = new PersonBuilder(ALICE).withNric(VALID_NRIC_BOB).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
+
+        /* NRIC differs in case, all other attributes same -> returns false
+        Person editedBob = new PersonBuilder(BOB).withNric(VALID_NRIC_BOB.toLowerCase()).build();
+        assertFalse(BOB.isSamePerson(editedBob));
+
+        // NRIC has trailing spaces, all other attributes same -> returns false
+        String nricWithTrailingSpaces = VALID_NRIC_BOB + " ";
+        editedBob = new PersonBuilder(BOB).withNric(nricWithTrailingSpaces).build();
+        assertFalse(BOB.isSamePerson(editedBob));
+         */
+    }
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        Person aliceCopy = new PersonBuilder(ALICE).build();
+        assertEquals(ALICE, aliceCopy);
+
+        // same object -> returns true
+        assertEquals(ALICE, ALICE);
+
+        // null -> returns false
+        assertNotEquals(null, ALICE);
+
+        // different type -> returns false
+        assertNotEquals(5, ALICE);
+
+        // different person -> returns false
+        assertNotEquals(ALICE, BOB);
+
+        // different nric -> returns false
+        Person editedAlice = new PersonBuilder(ALICE).withNric(VALID_NRIC_BOB).build();
+        assertNotEquals(ALICE, editedAlice);
+
+        // different phone -> returns false
+        editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
+        assertNotEquals(ALICE, editedAlice);
+
+        // different address -> returns false
+        editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).build();
+        assertNotEquals(ALICE, editedAlice);
+    }
+
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedVisitTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedVisitTest.java
@@ -1,0 +1,192 @@
+package seedu.address.storage;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+
+public class JsonAdaptedVisitTest {
+    private static final String INVALID_NRIC = "T-1";
+    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_PHONE = "+651234";
+    private static final String INVALID_ADDRESS = " ";
+    private static final String INVALID_DOB = "MARCH 10th 2021";
+    private static final String INVALID_SEX = "Male";
+    private static final String INVALID_STATUS = "DYING";
+
+    private static final String VALID_NRIC = BENSON.getNric().toString();
+    private static final String VALID_NAME = BENSON.getName().toString();
+    private static final String VALID_PHONE = BENSON.getPhone().toString();
+    private static final String VALID_ADDRESS = BENSON.getAddress().toString();
+    private static final String VALID_DOB = "2022-01-01";
+    private static final String VALID_SEX = BENSON.getSex().toString();
+    private static final String VALID_STATUS = BENSON.getStatus().toString();
+    private static final String VALID_EMAIL = "benson123@gmail.com";
+    private static final String VALID_COUNTRY = "Singapore";
+    private static final String VALID_ALLERGIES = "Peanuts";
+    private static final String VALID_BLOODTYPE = "A+";
+    private static final String VALID_CONDITION = "Diabetes";
+    private static final String VALID_DOA = "2024-01-01";
+    private static final String VALID_DIAGNOSIS = "Covid";
+    private static final String VALID_SYMPTOM = "Cough";
+
+    @Test
+    public void toModelType_validPersonDetails_returnsPerson() throws Exception {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(BENSON);
+        assertEquals(BENSON, person.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidNric_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(INVALID_NRIC, VALID_NAME, VALID_PHONE,
+                        VALID_ADDRESS, VALID_DOB, VALID_SEX, VALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = Nric.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullNric_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(null, VALID_NAME, VALID_PHONE,
+                        VALID_ADDRESS, VALID_DOB, VALID_SEX, VALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Nric.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+    @Test
+    public void toModelType_invalidName_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NRIC, INVALID_NAME, VALID_PHONE,
+                        VALID_ADDRESS, VALID_DOB, VALID_SEX, VALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = Name.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullName_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NRIC, null, VALID_PHONE,
+                        VALID_ADDRESS, VALID_DOB, VALID_SEX, VALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidPhone_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NRIC, VALID_NAME, INVALID_PHONE,
+                        VALID_ADDRESS, VALID_DOB, VALID_SEX, VALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullPhone_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NRIC, VALID_NAME, null,
+                        VALID_ADDRESS, VALID_DOB, VALID_SEX, VALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidAddress_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NRIC, VALID_NAME, VALID_PHONE,
+                        INVALID_ADDRESS, VALID_DOB, VALID_SEX, VALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = Address.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullAddress_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NRIC, VALID_NAME, VALID_PHONE,
+                        null, VALID_DOB, VALID_SEX, VALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+    @Test
+    public void toModelType_invalidDob_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NRIC, VALID_NAME, VALID_PHONE,
+                        VALID_ADDRESS, INVALID_DOB, VALID_SEX, VALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = DateOfBirth.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullDob_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NRIC, VALID_NAME, VALID_PHONE,
+                        VALID_ADDRESS, null, VALID_SEX, VALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, DateOfBirth.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+    @Test
+    public void toModelType_invalidSex_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NRIC, VALID_NAME, VALID_PHONE,
+                        VALID_ADDRESS, VALID_DOB, INVALID_SEX, VALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = Sex.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullSex_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NRIC, VALID_NAME, VALID_PHONE,
+                        VALID_ADDRESS, VALID_DOB, null, VALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Sex.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+    @Test
+    public void toModelType_invalidStatus_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NRIC, VALID_NAME, VALID_PHONE,
+                        VALID_ADDRESS, VALID_DOB, VALID_SEX, INVALID_STATUS, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = Status.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullStatus_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NRIC, VALID_NAME, VALID_PHONE,
+                        VALID_ADDRESS, VALID_DOB, VALID_SEX, null, VALID_EMAIL, VALID_COUNTRY,
+                        VALID_ALLERGIES, VALID_BLOODTYPE, VALID_CONDITION, VALID_DOA, VALID_DIAGNOSIS,
+                        VALID_SYMPTOM);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Status.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedVisitTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedVisitTest.java
@@ -1,14 +1,20 @@
 package seedu.address.storage;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.person.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.DateOfBirth;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Sex;
+import seedu.address.model.person.Status;
 public class JsonAdaptedVisitTest {
     private static final String INVALID_NRIC = "T-1";
     private static final String INVALID_NAME = "R@chel";

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -150,7 +150,7 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Phone} of the {@code Person} that we are building.
+     * Sets the {@code DateOfBirth} of the {@code DateOfBirth} that we are building.
      */
     public PersonBuilder withDateOfBirth(String dateOfBirth) {
         this.dateOfBirth = new DateOfBirth(dateOfBirth);
@@ -158,7 +158,7 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Sex} of the {@code Person} that we are building.
+     * Sets the {@code Sex} of the {@code Sex} that we are building.
      */
     public PersonBuilder withSex(String sex) {
         this.sex = new Sex(sex);
@@ -166,7 +166,7 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Status} of the {@code Person} that we are building.
+     * Sets the {@code Status} of the {@code Status} that we are building.
      */
     public PersonBuilder withStatus(String status) {
         this.status = new Status(status);
@@ -174,7 +174,7 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Phone} of the {@code Person} that we are building.
+     * Sets the {@code Email} of the {@code Email} that we are building.
      */
     public PersonBuilder withEmail(String email) {
         this.email = new Email(email);
@@ -182,7 +182,7 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Phone} of the {@code Person} that we are building.
+     * Sets the {@code Country} of the {@code Country} that we are building.
      */
     public PersonBuilder withCountry(String country) {
         this.country = new Country(country);
@@ -190,7 +190,7 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Phone} of the {@code Person} that we are building.
+     * Sets the {@code Allergies} of the {@code Allergies} that we are building.
      */
     public PersonBuilder withAllergies(String allergies) {
         this.allergies = new Allergies(allergies);
@@ -198,7 +198,7 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Phone} of the {@code Person} that we are building.
+     * Sets the {@code BloodType} of the {@code BloodType} that we are building.
      */
     public PersonBuilder withBloodType(String bloodType) {
         this.bloodType = new BloodType(bloodType);
@@ -206,7 +206,7 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Phone} of the {@code Person} that we are building.
+     * Sets the {@code Condition} of the {@code Condition} that we are building.
      */
     public PersonBuilder withCondition(String condition) {
         this.condition = new Condition(condition);
@@ -214,7 +214,7 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Phone} of the {@code Person} that we are building.
+     * Sets the {@code DateOfAdmission} of the {@code DateOfAdmission} that we are building.
      */
     public PersonBuilder withDateOfAdmission(String dateOfAdmission) {
         this.dateOfAdmission = new DateOfAdmission(dateOfAdmission);
@@ -222,7 +222,7 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Phone} of the {@code Person} that we are building.
+     * Sets the {@code Diagnosis} of the {@code Diagnosis} that we are building.
      */
     public PersonBuilder withDiagnosis(String diagnosis) {
         this.diagnosis = new Diagnosis(diagnosis);
@@ -230,7 +230,7 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Phone} of the {@code Person} that we are building.
+     * Sets the {@code Symptom} of the {@code Symptom} that we are building.
      */
     public PersonBuilder withSymptom(String symptom) {
         this.symptom = new Symptom(symptom);

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -5,10 +5,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import seedu.address.commons.core.index.Index;
-import seedu.address.model.Model;
-import seedu.address.model.person.Person;
-
 /**
  * A utility class for test cases.
  */

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -32,24 +32,4 @@ public class TestUtil {
         return SANDBOX_FOLDER.resolve(fileName);
     }
 
-    /**
-     * Returns the middle index of the person in the {@code model}'s person list.
-     */
-    public static Index getMidIndex(Model model) {
-        return Index.fromOneBased(model.getFilteredPersonList().size() / 2);
-    }
-
-    /**
-     * Returns the last index of the person in the {@code model}'s person list.
-     */
-    public static Index getLastIndex(Model model) {
-        return Index.fromOneBased(model.getFilteredPersonList().size());
-    }
-
-    /**
-     * Returns the person in the {@code model}'s person list at {@code index}.
-     */
-    public static Person getPerson(Model model, Index index) {
-        return model.getFilteredPersonList().get(index.getZeroBased());
-    }
 }

--- a/src/test/java/seedu/address/testutil/TypicalVisits.java
+++ b/src/test/java/seedu/address/testutil/TypicalVisits.java
@@ -1,0 +1,78 @@
+package seedu.address.testutil;
+
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATEOFVISIT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATEOFVISIT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DIAGNOSIS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DIAGNOSIS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SYMPTOM_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SYMPTOM_BOB;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.model.ImmuniMate;
+import seedu.address.model.visit.Visit;
+
+/**
+ * A utility class containing a list of {@code Person} objects to be used in tests.
+ */
+public class TypicalVisits {
+    // Basic Visits
+    public static final Visit VISIT_ALICE =
+        new VisitBuilder().withNric("T0139571B").withDateOfVisit("2023-01-01").withSymptom("Runny Nose, Headache")
+            .withDiagnosis("Common Flu").withStatus("UNWELL").build();
+    public static final Visit VISIT_BENSON = new VisitBuilder().withNric("T0439571C").withDateOfVisit("2022-02-15")
+        .withSymptom("Runny Nose, Loss of taste, Headache").withDiagnosis("COVID-19").withStatus("PENDING").build();
+    public static final Visit VISIT_CARL = new VisitBuilder().withNric("T0284994B").withDateOfVisit("2024-10-24")
+        .withSymptom("High fever, Headache, Nausea, Sore joints").withDiagnosis("Dengue").withStatus("UNWELL").build();
+
+    // Additional Visits
+    public static final Visit VISIT_ALICE_2 =
+        new VisitBuilder().withNric("T0139571B").withDateOfVisit("2023-01-14").withSymptom("NIL")
+            .withDiagnosis("Recovered").withStatus("HEALTHY").build();
+    public static final Visit VISIT_BENSON_2 = new VisitBuilder().withNric("T0439571C").withDateOfVisit("2022-02-25")
+        .withSymptom("Sore joints, trouble sleeping").withDiagnosis("Recovered").withStatus("HEALTHY").build();
+    public static final Visit VISIT_CARL_2 = new VisitBuilder().withNric("T0284994B").withDateOfVisit("2024-11-22")
+        .withSymptom("Fever, Headache, Nausea, Vomiting").withDiagnosis("Dengue").withStatus("UNWELL").build();
+    public static final Visit VISIT_ALICE_3 = new VisitBuilder().withNric("T0139571B").withDateOfVisit("2024-03-23")
+        .withSymptom("Dark Urine, Joint pain, Pale stool").withDiagnosis("Hepatitis B").withStatus("PENDING").build();
+    public static final Visit VISIT_BENSON_3 =
+        new VisitBuilder().withNric("T0439571C").withDateOfVisit("2023-01-02").withSymptom("Headache")
+            .withDiagnosis("NIL").withStatus("HEALTHY").build();
+    public static final Visit VISIT_CARL_3 =
+        new VisitBuilder().withNric("T0284994B").withDateOfVisit("2024-10-24").withSymptom("Slight Headache")
+            .withDiagnosis("Recovered").withStatus("HEALTHY").build();
+
+    // Manually added - Person's details found in {@code CommandTestUtil}
+    public static final Visit VISIT_AMY =
+        new VisitBuilder().withNric(VALID_NRIC_AMY).withDateOfVisit(VALID_DATEOFVISIT_AMY)
+            .withSymptom(VALID_SYMPTOM_AMY).withDiagnosis(VALID_DIAGNOSIS_AMY).withStatus(VALID_STATUS_AMY).build();
+    public static final Visit VISIT_BOB =
+        new VisitBuilder().withNric(VALID_NRIC_BOB).withDateOfVisit(VALID_DATEOFVISIT_BOB)
+            .withSymptom(VALID_SYMPTOM_BOB).withDiagnosis(VALID_DIAGNOSIS_BOB).withStatus(VALID_STATUS_BOB).build();
+
+    private TypicalVisits() {
+    } // prevents instantiation
+
+    /**
+     * Returns an {@code AddressBook} with all the typical visits.
+     */
+    public static ImmuniMate getTypicalAddressBook() {
+        ImmuniMate ab = new ImmuniMate();
+        for (Visit visit : getTypicalVisits()) {
+            ab.addVisit(visit);
+        }
+        return ab;
+    }
+
+    public static List<Visit> getTypicalVisits() {
+        return new ArrayList<>(
+            Arrays.asList(VISIT_ALICE, VISIT_ALICE_2, VISIT_ALICE_3, VISIT_BENSON, VISIT_BENSON_2, VISIT_BENSON_3,
+                VISIT_CARL, VISIT_CARL_2, VISIT_CARL_3, VISIT_AMY, VISIT_BOB));
+    }
+}

--- a/src/test/java/seedu/address/testutil/VisitBuilder.java
+++ b/src/test/java/seedu/address/testutil/VisitBuilder.java
@@ -89,6 +89,6 @@ public class VisitBuilder {
      * Returns a Person object with fields initialised to that of PersonBuilder object.
      */
     public Visit build() {
-      return new Visit(nric, dateOfVisit, symptom, diagnosis, status);
+        return new Visit(nric, dateOfVisit, symptom, diagnosis, status);
     }
 }

--- a/src/test/java/seedu/address/testutil/VisitBuilder.java
+++ b/src/test/java/seedu/address/testutil/VisitBuilder.java
@@ -89,7 +89,6 @@ public class VisitBuilder {
      * Returns a Person object with fields initialised to that of PersonBuilder object.
      */
     public Visit build() {
-        Visit v = new Visit(nric, dateOfVisit, symptom, diagnosis, status);
-        return v;
+      return new Visit(nric, dateOfVisit, symptom, diagnosis, status);
     }
 }

--- a/src/test/java/seedu/address/testutil/VisitBuilder.java
+++ b/src/test/java/seedu/address/testutil/VisitBuilder.java
@@ -1,0 +1,95 @@
+package seedu.address.testutil;
+
+
+import seedu.address.model.person.Diagnosis;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Status;
+import seedu.address.model.person.Symptom;
+import seedu.address.model.visit.DateOfVisit;
+import seedu.address.model.visit.Visit;
+
+/**
+ * A utility class to help with building Visit objects.
+ */
+public class VisitBuilder {
+    // Default NRIC should match an existing Person.
+    public static final String DEFAULT_NRIC = "T1234567B";
+    public static final String DEFAULT_DOV = "2024-01-01";
+    public static final String DEFAULT_SYMPTOM = "Runny nose, headache";
+    public static final String DEFAULT_DIAGNOSIS = "COVID-19";
+    public static final String DEFAULT_STATUS = "UNWELL";
+
+
+    // Mandatory fields
+    private Nric nric;
+    private DateOfVisit dateOfVisit;
+    private Symptom symptom;
+    private Diagnosis diagnosis;
+    private Status status;
+
+
+    /**
+     * Creates a {@code VisitBuilder} with the default details.
+     */
+    public VisitBuilder() {
+        nric = new Nric(DEFAULT_NRIC);
+        dateOfVisit = new DateOfVisit(DEFAULT_DOV);
+        symptom = new Symptom(DEFAULT_SYMPTOM);
+        diagnosis = new Diagnosis(DEFAULT_DIAGNOSIS);
+        status = new Status(DEFAULT_STATUS);
+    }
+
+    /**
+     * Initializes the VisitBuilder with the data of {@code visitToCopy}.
+     */
+    public VisitBuilder(Visit visitToCopy) {
+        nric = visitToCopy.getNric();
+        dateOfVisit = visitToCopy.getDateOfVisit();
+        symptom = visitToCopy.getSymptom();
+        diagnosis = visitToCopy.getDiagnosis();
+        status = visitToCopy.getStatus();
+    }
+    /**
+     * Sets the {@code Nric} of the {@code Visit} that we are building.
+     */
+    public VisitBuilder withNric(String nric) {
+        this.nric = new Nric(nric);
+        return this;
+    }
+    /**
+     * Sets the {@code DateOfVisit} of the {@code Visit} that we are building.
+     */
+    public VisitBuilder withDateOfVisit(String dateOfVisit) {
+        this.dateOfVisit = new DateOfVisit(dateOfVisit);
+        return this;
+    }
+    /**
+     * Sets the {@code Symptom} of the {@code Visit} that we are building.
+     */
+    public VisitBuilder withSymptom(String symptom) {
+        this.symptom = new Symptom(symptom);
+        return this;
+    }
+    /**
+     * Sets the {@code Diagnosis} of the {@code Visit} that we are building.
+     */
+    public VisitBuilder withDiagnosis(String diagnosis) {
+        this.diagnosis = new Diagnosis(diagnosis);
+        return this;
+    }
+    /**
+     * Sets the {@code Status} of the {@code Person} that we are building.
+     */
+    public VisitBuilder withStatus(String status) {
+        this.status = new Status(status);
+        return this;
+    }
+
+    /**
+     * Returns a Person object with fields initialised to that of PersonBuilder object.
+     */
+    public Visit build() {
+        Visit v = new Visit(nric, dateOfVisit, symptom, diagnosis, status);
+        return v;
+    }
+}

--- a/src/test/java/seedu/address/testutil/VisitUtil.java
+++ b/src/test/java/seedu/address/testutil/VisitUtil.java
@@ -1,0 +1,36 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.AddVisitCommand;
+import seedu.address.logic.commands.CreateCommand;
+import seedu.address.logic.commands.UpdateCommand.UpdatePersonDescriptor;
+import seedu.address.model.person.Person;
+import seedu.address.model.visit.Visit;
+
+import static seedu.address.logic.parser.CliSyntax.*;
+
+/**
+ * A utility class for Visit.
+ */
+public class VisitUtil {
+
+    /**
+     * Returns an add command string for adding the {@code visit}.
+     */
+    public static String getAddVisitCommand(Visit visit) {
+        return AddVisitCommand.COMMAND_WORD + " " + getVisitDetails(visit);
+    }
+
+    /**
+     * Returns the part of command string for the given {@code visit}'s details.
+     */
+    public static String getVisitDetails(Visit visit) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(PREFIX_NRIC + visit.getNric().toString() + " ");
+        sb.append(PREFIX_DATEOFVISIT + visit.getDateOfVisit().toString() + " ");
+        sb.append(PREFIX_SYMPTOM + visit.getSymptom().toString() + " ");
+        sb.append(PREFIX_DIAGNOSIS + visit.getDiagnosis().toString() + " ");
+        sb.append(PREFIX_STATUS + visit.getStatus().toString() + " ");
+        return sb.toString();
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/VisitUtil.java
+++ b/src/test/java/seedu/address/testutil/VisitUtil.java
@@ -1,12 +1,13 @@
 package seedu.address.testutil;
 
-import seedu.address.logic.commands.AddVisitCommand;
-import seedu.address.logic.commands.CreateCommand;
-import seedu.address.logic.commands.UpdateCommand.UpdatePersonDescriptor;
-import seedu.address.model.person.Person;
-import seedu.address.model.visit.Visit;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATEOFVISIT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DIAGNOSIS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SYMPTOM;
 
-import static seedu.address.logic.parser.CliSyntax.*;
+import seedu.address.logic.commands.AddVisitCommand;
+import seedu.address.model.visit.Visit;
 
 /**
  * A utility class for Visit.


### PR DESCRIPTION
Fix AddVisitCommand bug where you can add a visit with invalid nric. 
Fix bug where visit was improperly stored in Storage due to LogicManager.
Add TypicalVisits and other Visit files

Additional:
Fix CommandBox bug due to improper indexing
Remove unnecessary println() methods in CommandBox